### PR TITLE
Added the paintbrushPointed glyph to the glyphs list

### DIFF
--- a/src/assets/glyphs.json
+++ b/src/assets/glyphs.json
@@ -505,5 +505,6 @@
     "seal": 62499,
     "rhombus": 62500,
     "shield": 62501,
-    "shazam": 61796
+    "shazam": 61796,
+    "paintbrushPointed": 61749
 }


### PR DESCRIPTION
Adds the `paintbrushPointed` SF Symbol glyph (code 61749) which was missing from the glyphs list. Companion to the cherri PR adding the same glyph there.